### PR TITLE
fix sign-compare warning

### DIFF
--- a/src/resParser.l
+++ b/src/resParser.l
@@ -76,7 +76,7 @@ if ( input_stream_ptr->atEnd() ) {                                     \
    result = YY_NULL;                                                   \
 }                                                                      \
 else {                                                                 \
-   unsigned int ii = 0;                                                \
+   int ii = 0;                                                \
    for ( ; (ii < max_size) && (!input_stream_ptr->atEnd()); ++ii ) {   \
 	(*input_stream_ptr) >> buf[ii]; \
    }                                                                   \


### PR DESCRIPTION
```
resParser_lex.cpp: In function ‘int yy_get_next_buffer()’:
resParser.l:80:16: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘int’ [-Wsign-compare]
   80 |    for ( ; (ii < max_size) && (!input_stream_ptr->atEnd()); ++ii ) {   \
resParser_lex.cpp:1904:3: note: in expansion of macro ‘YY_INPUT’
 1904 |   /* Read in more data. */
      |   ^~~~~~~~
```
