### PR TITLE
Syntax Error Fixes when running setup script.

### DIFF
--- a/lib/python/xxdiff/scripts/cvsrevcmp.py
+++ b/lib/python/xxdiff/scripts/cvsrevcmp.py
@@ -212,7 +212,7 @@ def cvsxxdiff_bi_bj(diff_files, prevcounts):
         print(mkheader(fn))
 
         # Get revision numbers.
-        v1, v2 = [get_previous_revision(fn, prevcounts[x]) for x in 0, 1]
+        v1, v2 = [get_previous_revision(fn, prevcounts[x]) for x in [0, 1]]
 
         # Get the files from the server.
         tmpfiles = []

--- a/lib/python/xxdiff/scripts/svndiff.py
+++ b/lib/python/xxdiff/scripts/svndiff.py
@@ -63,7 +63,7 @@ def review_file(sobj, opts):
                 # Get the source filename from the history.
                 info = subversion.getinfo(sobj.filename)
                 from_url, from_rev = [info.get('Copied From %s' % x, None)
-                                      for x in 'URL', 'Rev']
+                                      for x in ['URL', 'Rev']]
 
                 tmpf = subversion.cat_revision_temp(sobj.filename, 'BASE')
                 dopts.extend(title_opts('%s (%s)' % (from_url, from_rev)))


### PR DESCRIPTION
After building and running the setup script using python3 setup.py install, the following errors are thrown:

```
byte-compiling /usr/local/lib/python3.6/dist-packages/xxdiff/scripts/cvsrevcmp.py to cvsrevcmp.cpython-36.pyc
  File "/usr/local/lib/python3.6/dist-packages/xxdiff/scripts/cvsrevcmp.py", line 215
    v1, v2 = [get_previous_revision(fn, prevcounts[x]) for x in 0, 1]
                                                                 ^
SyntaxError: invalid syntax
```

and
```

byte-compiling /usr/local/lib/python3.6/dist-packages/xxdiff/scripts/svndiff.py to svndiff.cpython-36.pyc
  File "/usr/local/lib/python3.6/dist-packages/xxdiff/scripts/svndiff.py", line 66
    for x in 'URL', 'Rev']
                  ^
SyntaxError: invalid syntax
```

Changes to syntax were made to fix the issue.