### PR TITLE
MacOS: Small fix for Apple Silicon

### DIFF
--- a/ports/macosx/README.macosx
+++ b/ports/macosx/README.macosx
@@ -6,11 +6,12 @@
 :Date: 2005-06-03
 :Abstract:
 
-   Notes on how to build xxdiff for MAC OSX. 
+   Notes on how to build xxdiff for MAC OSX.
    I don't own an Apple computer yet, so I haven't done any of this myself.
 
 .. contents::
 ..
+    0 From Alexandre Feblot (2024-11-17)
     1  From Trevor Harmon (2006-05-31)
     2  Alexandre Feblot (2005-06-03)
     3  Building under Mac OS X w/ XFree86 port (old)
@@ -18,10 +19,35 @@
     4  Matt Johnston <matt@ucc.asn.au>
 
 
+From Alexandre Feblot (2024-11-17)
+==================================
+
+Validated with
+  - Apple Silicon M4
+  - MacOS 15.1 Sequoia
+  - Qt 6.8
+
+1) Qt Installation
+  * Simplest solution would be : brew install qt6
+    But this version of qt currently breaks the packaging step (make dmg) allowing to
+    obtain a self-contained application with no dependency on the Qt Installation
+    cf. https://github.com/orgs/Homebrew/discussions/2823
+  * Official binary distribution downloaded from https://www.qt.io/download-qt-installer-oss
+
+2) Compilation
+  QTDIR=....
+  export PATH=$QTDIR/bin:$PATH
+  make -f Makefile.bootstrap
+  make
+
+3) Creation of the self contained application
+   (stripped to only contain the arm64 or x86_64 code)
+   make dmg
+
 From Trevor Harmon (2006-05-31)
 ===============================
 
-  From: Trevor Harmon <trevor@vocaro.com>	
+  From: Trevor Harmon <trevor@vocaro.com>
   To: Martin Blais <blais@furius.ca>
   Date: May 31, 2006 7:43 PM
   Subject: xxdiff for Mac
@@ -448,7 +474,7 @@ A port to Mac OS X by Alexandre has shown up in november 2010:
   below the list of current changes compared to your dev version.
   Please, give me a sign, let me know what to do with this code. Shall I
   provide you the repository? Shall I put it online somewhere, which
-  would mean creating a fork (I'd hate this idea)? 
+  would mean creating a fork (I'd hate this idea)?
 
   Regards,
 
@@ -459,7 +485,7 @@ A port to Mac OS X by Alexandre has shown up in november 2010:
     which we understand when unmerging. Those markers may be customized
     with resources Tag.Conflict.{Start,Sep,SepExtra,End} which replace
     Tag.Conflict.Separator. %L, %M, %R are replaced by left, middle and right files.
-  * GUI refresh to show a more modern look (frames, file labels, line numbers, 
+  * GUI refresh to show a more modern look (frames, file labels, line numbers,
     cursor)
   * Allow to clear search results by searching for an empty string
   * Add instant search bar in the online user's manual

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -112,7 +112,7 @@ void XxResources::initializeOriginalXdiff()
    _preferredGeometry = _defaultGeometry;
    _styleKey =  // Default style.
 #ifdef Q_OS_MAC
-      "Macintosh";
+      "macOS";
 #elif defined(Q_OS_WIN)
       "Windows";
 #else

--- a/src/xxdiff.pro
+++ b/src/xxdiff.pro
@@ -134,14 +134,14 @@ macx {
 
    BUNDLE = $$DESTDIR/$$TARGET".app"
 
-   # Copy all required frameworks (libs) in the bundle, and remove i386 part of libs (only keep x86_64)
+   # Copy all required frameworks (libs) in the bundle, and only keep the current architecture from the universal binaries (arm64 or x86_64)
    macdeployqt.target = $$BUNDLE/Contents/Resources/qt.conf
-   macdeployqt.commands = macdeployqt $$BUNDLE; for l in `find $$BUNDLE -type f -name '*.dylib'; find $$BUNDLE/Contents/Frameworks -type f -name 'Qt*'`; do if [ \$\$(lipo \$\$l -info | grep -c 'Non-fat') != 1 ]; then lipo \$\$l -thin x86_64 -output \$\$l; fi; done
+   macdeployqt.commands = macdeployqt $$BUNDLE; for l in `find $$BUNDLE -type f -name '*.dylib'; find $$BUNDLE/Contents/Frameworks -type f -name 'Qt*'`; do if [ \$\$(lipo \$\$l -info | grep -c 'Non-fat') != 1 ]; then lipo \$\$l -thin $$QMAKE_HOST.arch -output \$\$l; fi; done
    macdeployqt.depends = $$BUNDLE
 
    # Create a dmg package
    VER = $$system(cat ../VERSION)
-   DMG = $$DESTDIR/$$TARGET"_"$$VER".dmg"
+   DMG = $$DESTDIR/$$TARGET"_"$$VER"-Qt_"$$QT_VERSION"-"$$QMAKE_HOST.arch".dmg"
    dmg.target = $$DMG
    dmg.commands = @hdiutil create -ov -fs HFS+ -srcfolder $$BUNDLE -volname $$quote("xxdiff\\ $$VER") $$DMG
    dmg.depends = $$macdeployqt.target $(TARGET)
@@ -152,7 +152,7 @@ macx {
    bison23lnk.depends = bison23src resParser_bison23_yacc.h resParser_bison23.y
    bison23src.target = resParser_bison23.y
    bison23src.commands = perl -pe \'s/define api.pure/pure-parser/\' resParser.y > resParser_bison23.y
-   bison23src.depends = 
+   bison23src.depends =
    YACCSOURCES = resParser_bison23.y
    QMAKE_YACCFLAGS_MANGLE = -p resParser -b resParser
    resParser_lex_obj.target = resParser_lex.o


### PR DESCRIPTION
Happy to report that xxdiff builds fine on MacOS Sequoia on Apple Silicon with Qt 6.8.

Just 2 tiny changes were required:
- Update the default style name to avoid a runtime warning
- Update the strip command to only keep the required architecture code in fat libraries (arm64 or x86_86)