### PR TITLE
Qt3 buildagain 2025

### DIFF
--- a/src/accelUtil.cpp
+++ b/src/accelUtil.cpp
@@ -73,7 +73,6 @@ const KeyPair keycodes[] = {
    { "@", Qt::Key_At },
    { "[", Qt::Key_BracketLeft },
    { "\\", Qt::Key_Backslash },
-   { "]", Qt::Key_BraceRight },
    { "]", Qt::Key_BracketRight },
    { "_", Qt::Key_Underscore },
    { "`", Qt::Key_QuoteLeft },
@@ -197,6 +196,7 @@ const KeyPair keycodes[] = {
    { "z", Qt::Key_Z },
    { "{", Qt::Key_BraceLeft },
    { "|", Qt::Key_Bar },
+   { "}", Qt::Key_BraceRight },
    { "~", Qt::Key_AsciiTilde },
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,6 +51,7 @@ XX_NAMESPACE_USING
 
 extern char** environ;
 static char s_env_string_LC_ALL[] = "LC_ALL=C";
+static char s_env_string_LANG[] = "LANG=C";
 
 //------------------------------------------------------------------------------
 //
@@ -60,6 +61,8 @@ int main( int argc, char** argv, char** envp )
 
    // Override user locale or xxdiff could not parse localized diff output...
    putenv(s_env_string_LC_ALL);
+   // Ditto, override LANG, for filenames with 8-bit chars to work...
+   putenv(s_env_string_LANG);
 
    int retval = 2; // errors.
    try {

--- a/src/main.h
+++ b/src/main.h
@@ -35,6 +35,10 @@
  * PUBLIC DECLARATIONS
  *============================================================================*/
 
+extern "C" {
+
 extern char** environ;
+
+}
 
 #endif

--- a/src/resParser.cpp
+++ b/src/resParser.cpp
@@ -69,11 +69,11 @@
  *============================================================================*/
 
 // Parser routine defined in the yacc parser.
-extern int resParserparse( void* );
+extern int resParserparse( XxResources* );
 
 //------------------------------------------------------------------------------
 //
-void resParsererror( const char* msg )
+void resParsererror( void *, const char* msg )
 {
    // Send errors to stdout so we can filter out the debug info shmeglu while
    // debugging parser.
@@ -786,7 +786,7 @@ int parseFromKeywordList(
       QString os;
       QTextOStream oss( &os );
       oss << "Unknown " << errmsg << ": " << name << flush;
-      resParsererror( os.latin1() );
+      resParsererror( NULL, os.latin1() );
    }
    num = ERROR_TOKEN;
    return ERROR_TOKEN;

--- a/src/resParser.l
+++ b/src/resParser.l
@@ -76,7 +76,7 @@ if ( input_stream_ptr->atEnd() ) {                                     \
    result = YY_NULL;                                                   \
 }                                                                      \
 else {                                                                 \
-   int ii = 0;                                                         \
+   unsigned int ii = 0;                                                \
    for ( ; (ii < max_size) && (!input_stream_ptr->atEnd()); ++ii ) {   \
 	input_stream_ptr->readRawBytes( &buf[ii], 1 );                 \
    }                                                                   \

--- a/src/resParser.y
+++ b/src/resParser.y
@@ -20,11 +20,6 @@
  *
  ******************************************************************************/
 
-%union
-{
-    int   num;
-    char* str;
-}
 %{
 
 // xxdiff imports
@@ -39,12 +34,23 @@
 
 // The parser input is the resources object to fill in.
 #define RESOURCES  ( static_cast<XxResources*>(resources) )
-#define YYPARSE_PARAM resources
+%}
 
+%define api.pure
+
+%parse-param {XxResources * resources}
+
+%union
+{
+    int   num;
+    char* str;
+}
+
+%{
 // Declare lexer from other compilation unit.
 int resParserlex( YYSTYPE* yylval );
 
-void resParsererror( const char* msg );
+void resParsererror( void *, const char* msg );
 
 // Declare some parser functions and data defined in resParser.cpp
 namespace XxResParserNS {
@@ -53,8 +59,6 @@ bool readGeometry( const QString& val, QRect& geometry );
 
 }
 using namespace XxResParserNS; // Make sure we can use the above.
-
-
 
 %}
 
@@ -144,7 +148,6 @@ using namespace XxResParserNS; // Make sure we can use the above.
 %type <num> boolkwd
 
 %start xxdiffrc
-%pure_parser
 
 %%
 xxdiffrc	: stmts
@@ -188,7 +191,7 @@ prefgeometry	: PREFGEOMETRY COLON GEOMSPEC
                       RESOURCES->setPreferredGeometry( geometry );
                    }
                    else {
-                      yyerror( "Bad geometry specification." );
+                      yyerror( NULL, "Bad geometry specification." );
                       // Should never happen, the lexer regexp should be tough
                       // enough.
                    }
@@ -216,7 +219,7 @@ style		: STYLE COLON STRING
                       err += QString( "\nValid styles are: " );
                       err += styles.join( ", " );
 #endif
-                      yyerror( err.latin1() );
+                      yyerror( NULL, err.latin1() );
 #if (QT_VERSION >= 0x030000)
                    }
 #endif
@@ -230,7 +233,7 @@ accel		: ACCEL DOT ACCELNAME COLON STRING
                       char buf[2048];
                       ::snprintf( buf, 2048,
                                   "Unrecognized accelerator: %s\n", $5 );
-                      yyerror( buf );
+                      yyerror( NULL, buf );
                    }
                 }
 		;


### PR DESCRIPTION
commits on top of 9ee2fd4e7a096 (2020-11-12)

1st commit makes the old qt3 version of xxdiff build in today's linux system (almost out of the box in Fedora 41)

2nd puts extern char **environment in C linkage block, some compilers (rightfully) complains about it

3rd: the sorted list of (accelerator) keycodes had BraceRight as ']' and in "wrong" place (or that's how it looks to me)

and last, 4th in this stack. In case of qt3 - in my experience, xxdiff failed to open file if it's path contained 8-bit
chars (utf-8 ones). When, in addotion to LC_ALL, LANG was set to "C" then those files opened and I could diff.
This may be very different in latest version (and those warnings with xxdiff-qt6 seen in issues), but that's how
it seems to work here in qt3 version.
