### PR TITLE
Added option --title <arg> to set text in xxdiff window title bar

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -445,7 +445,10 @@ XxApp::XxApp( int& argc, char** argv, XxCmdline& cmdline ) :
    adjustLineNumbers();
 
    // Sets the title bar.
-   if ( _nbFiles == 2 ) {
+   if (!_cmdline._titleText.isEmpty()) {
+      _mainWindow->setCaption( _cmdline._titleText );
+   }
+   else if ( _nbFiles == 2 ) {
       QString str =
          QString(_files[0]->getDisplayName()) + " <-> " +
          QString(_files[1]->getDisplayName());

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -218,6 +218,9 @@ XxCmdline::Option XxCmdline::_optionsXxdiff[] = {
 // Display options
 //
 XxCmdline::Option XxCmdline::_optionsDisplay[] = {
+   { "title", 0, true, '0', 
+     "Display 'str' in xxdiff window title bar."
+   }, 
    { "title1", 0, true, '1', 
      "Display 'str' instead of filename in filename label 1 (left)."
    }, 
@@ -357,6 +360,7 @@ XxCmdline::XxCmdline() :
    _nbQtOptions( 0 ),
    _qtOptions()
 {
+   _titleText = "";
    _userFilenames[0] = "";
    _userFilenames[1] = "";
    _userFilenames[2] = "";
@@ -517,6 +521,14 @@ bool XxCmdline::parseCommandLine( const int argc, char* const* argv )
          case 'S': {
             _single = true;
          } break;
+
+         case '0':
+            if ( !optarg ) {
+               throw XxUsageError( XX_EXC_PARAMS,
+                                   "Missing argument for title option." );
+            }
+            _titleText = optarg;
+            break;
 
          case '1':
             if ( !optarg ) {

--- a/src/cmdline.h
+++ b/src/cmdline.h
@@ -122,6 +122,7 @@ private:
    bool          _forceFont;
 
    bool          _originalXdiff;
+   QString       _titleText;
    QString       _userFilenames[3];
    QString       _stdinFilename;
    bool          _useRcfile;


### PR DESCRIPTION

--

For reference, to build on Fedora 41:
```
$ cd src
$ make -f Makefile.bootstrap makefile QTDIR=/usr/lib64/qt-3.3 QMAKE=/usr/lib64/qt-3.3/bin/qmake
$ make QTDIR=/usr/lib64/qt-3.3
```
The qt3 rpm package needed in this particular test build: `qt3-devel-3.3.8b-99.fc41.x86_64`