### PR TITLE
fix escapes in python regexes

### DIFF
--- a/lib/python/xxdiff/db/postgresql.py
+++ b/lib/python/xxdiff/db/postgresql.py
@@ -112,7 +112,7 @@ def dump_schema(user, dbname, schema, opts):
     return dump
 
 
-sec_re = re.compile('^-- (?:Data for )?Name:\s*([^\s;]+);\s*Type:\s*([^;]+);(.*)$', re.M)
+sec_re = re.compile('^-- (?:Data for )?Name:\\s*([^\\s;]+);\\s*Type:\\s*([^;]+);(.*)$', re.M)
 com_re = re.compile('--.*$', re.M)
 ct_re = re.compile('^CREATE TABLE.*?(\\().*?(\\);)', re.M|re.S)
 

--- a/lib/python/xxdiff/scm/cvs.py
+++ b/lib/python/xxdiff/scm/cvs.py
@@ -40,7 +40,7 @@ def unmerge2(text):
     files.  This is not meant to work with three files.
     """
     begre = re.compile('^<<<<<<< (.*)')
-    sepre = re.compile('^=======\s*$')
+    sepre = re.compile('^=======\\s*$')
     endre = re.compile('^>>>>>>> (.*)')
 
     OUT, IN1, IN2 = 0, 1, 2

--- a/lib/python/xxdiff/scripts/cvsrevcmp.py
+++ b/lib/python/xxdiff/scripts/cvsrevcmp.py
@@ -69,7 +69,7 @@ def find_in_trunk(search_directories, fn):
                 files.append(join(root, fn))
     return files
 
-match_status = re.compile('File:\s*([^\s]+)\s*Status: (.*)')
+match_status = re.compile('File:\\s*([^\\s]+)\\s*Status: (.*)')
 
 def collect_unupdated_files(diff_directories, resolve_conflicts):
     """
@@ -115,14 +115,14 @@ def get_local_trunk_version(filename):
     dn, bn = split(filename)
 
     lines = open(join(dn, 'CVS', 'Entries')).readlines()
-    match_unupdated = re.compile('/%s/([0-9\.]*)' % bn)
+    match_unupdated = re.compile('/%s/([0-9.]*)' % bn)
     for l in lines:
         m = match_unupdated.search(l)
         if  m:
             return m.group(1)
     return '1.1'
 
-match_repository_rev = re.compile('Repository revision:\s([0-9\.]*)')
+match_repository_rev = re.compile('Repository revision:\\s([0-9.]*)')
 
 def get_repository_revision(filename):
     """

--- a/lib/python/xxdiff/scripts/svnresolve.py
+++ b/lib/python/xxdiff/scripts/svnresolve.py
@@ -101,7 +101,7 @@ def svnresolve_main():
 
         # Spawn xxdiff in decision mode on the three files. We dispatch to the
         # encrypted version if necessary.
-        if re.match('.*\.asc', s.filename):
+        if re.match('.*\\.asc', s.filename):
             tmine = open(mine).read()
             tancestor = open(ancestor).read()
             tyours = open(yours).read()

--- a/lib/python/xxdiff/selectfiles.py
+++ b/lib/python/xxdiff/selectfiles.py
@@ -51,8 +51,8 @@ def options_graft(parser):
             getattr(parser.values, option.dest).append(const)
         return cb
 
-    for fname, ftype, fregexp in (('C++', 'cpp', '.*\.(h(pp)?|c(pp|\+\+|c)?)$'),
-                                  ('Python', 'py', '.*\.py$')):
+    for fname, ftype, fregexp in (('C++', 'cpp', '.*\\.(h(pp)?|c(pp|\\+\\+|c)?)$'),
+                                  ('Python', 'py', '.*\\.py$')):
 
         group.add_option('--%s' % ftype, '--select-%s' % ftype, dest='select',
             action='callback', callback=append_const_cb(re.compile(fregexp)),
@@ -101,7 +101,7 @@ def options_graft(parser):
     return group
 
 
-ignore_defaults = ('CVS', '\.(svn|git|hg|bzr)$')
+ignore_defaults = ('CVS', '\\.(svn|git|hg|bzr)$')
 
 def options_validate(opts, parser, logs=None):
     """


### PR DESCRIPTION
In a python string, a backslash is an escape character, and needs to be escaped to put a literal backslash into the regex

This fixes a number of "SyntaxWarning: invalid escape sequence '\s' ..." when byte-compiling the python source, e.g. on package installation:

```
  Setting up xxdiff-scripts (1:5.1+git20240417+dfsg-2) ...
  /usr/lib/python3/dist-packages/xxdiff/db/postgresql.py:115:
SyntaxWarning: invalid escape sequence '\s'
    sec_re = re.compile('^-- (?:Data for
)?Name:\s*([^\s;]+);\s*Type:\s*([^;]+);(.*)$', re.M)
  /usr/lib/python3/dist-packages/xxdiff/scm/cvs.py:43: SyntaxWarning:
invalid escape sequence '\s'
    sepre = re.compile('^=======\s*$')
  /usr/lib/python3/dist-packages/xxdiff/scripts/cvsrevcmp.py:72:
SyntaxWarning: invalid escape sequence '\s'
    match_status = re.compile('File:\s*([^\s]+)\s*Status: (.*)')
  /usr/lib/python3/dist-packages/xxdiff/scripts/cvsrevcmp.py:118:
SyntaxWarning: invalid escape sequence '\.'
    match_unupdated = re.compile('/%s/([0-9\.]*)' % bn)
  /usr/lib/python3/dist-packages/xxdiff/scripts/cvsrevcmp.py:125:
SyntaxWarning: invalid escape sequence '\s'
    match_repository_rev = re.compile('Repository revision:\s([0-9\.]*)')
  /usr/lib/python3/dist-packages/xxdiff/scripts/svnresolve.py:104:
SyntaxWarning: invalid escape sequence '\.'
    if re.match('.*\.asc', s.filename):
  /usr/lib/python3/dist-packages/xxdiff/selectfiles.py:54:
SyntaxWarning: invalid escape sequence '\.'
    for fname, ftype, fregexp in (('C++', 'cpp', '.*\.(h(pp)?|c(pp|\+\+|c)?)$'),
  /usr/lib/python3/dist-packages/xxdiff/selectfiles.py:55:
SyntaxWarning: invalid escape sequence '\.'
    ('Python', 'py', '.*\.py$')):
  /usr/lib/python3/dist-packages/xxdiff/selectfiles.py:104:
SyntaxWarning: invalid escape sequence '\.'
    ignore_defaults = ('CVS', '\.(svn|git|hg|bzr)$')
```